### PR TITLE
Introduce changes to work more efficiently with Player and Team entities in the application with the help of Data Transfer Objects and Mappers. 

### DIFF
--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/controller/PlayerController.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/controller/PlayerController.java
@@ -1,5 +1,7 @@
 package com.tournament_organizer.controller;
 
+import com.tournament_organizer.dto.player.PlayerInDTO;
+import com.tournament_organizer.dto.player.PlayerOutDTO;
 import com.tournament_organizer.entity.Player;
 import com.tournament_organizer.service.PlayerService;
 import jakarta.validation.Valid;
@@ -21,13 +23,14 @@ public class PlayerController {
     }
 
     @PostMapping
-    public ResponseEntity< Player >createPlayer(@Valid @RequestBody Player Player) {
-        Player created = playerService.save(Player);
+    public ResponseEntity< PlayerOutDTO >createPlayer(@Valid @RequestBody PlayerInDTO playerInDTO) {
+        PlayerOutDTO created = playerService.save(playerInDTO);
+
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @GetMapping
-    public List<Player> getAllPlayers() {
+    public List<PlayerOutDTO> getAllPlayers() {
         return playerService.findAll();
     }
 
@@ -37,10 +40,10 @@ public class PlayerController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity <Player> updatePlayer(@PathVariable(value = "id") Long playerId,
-                                                      @Valid @RequestBody Player playerDetails) {
-        Player player = playerService.update(playerId, playerDetails);
-        return ResponseEntity.ok(player);
+    public ResponseEntity <PlayerOutDTO> updatePlayer(@PathVariable(value = "id") Long playerId,
+                                                      @Valid @RequestBody PlayerInDTO playerInDTO) {
+        PlayerOutDTO playerOutDTO = playerService.update(playerId, playerInDTO);
+        return ResponseEntity.ok(playerOutDTO);
     }
 
     @DeleteMapping("/{id}")
@@ -48,6 +51,7 @@ public class PlayerController {
     public void deletePlayer(@PathVariable Long id) {
         playerService.deleteById(id);
     }
+
     @PostMapping("/{playerId}/team/{teamId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void addToTeam(@PathVariable Long playerId,

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/controller/TeamController.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/controller/TeamController.java
@@ -1,9 +1,11 @@
+
 package com.tournament_organizer.controller;
 
-import com.tournament_organizer.entity.Team;
+import com.tournament_organizer.dto.team.TeamInDTO;
+import com.tournament_organizer.dto.team.TeamOutDTO;
 import com.tournament_organizer.service.TeamService;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,37 +14,38 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/v1/teams")
 public class TeamController {
+
     private final TeamService teamService;
-    @Autowired
+
     public TeamController(TeamService teamService) {
         this.teamService = teamService;
     }
 
     @PostMapping
-    public Team createTeam(@Valid @RequestBody Team team) {
-        return teamService.save(team);
+    public ResponseEntity<TeamOutDTO> createTeam(@Valid @RequestBody TeamInDTO dto) {
+        TeamOutDTO created = teamService.save(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @GetMapping
-    public List<Team> getAllTeams() {
+    public List<TeamOutDTO> getAllTeams() {
         return teamService.findAll();
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<Team> updateTeam(@PathVariable(value = "id") Long teamId,
-                                               @Valid @RequestBody Team teamDetails) {
-        Team updatedTeam = teamService.update(teamId, teamDetails);
-        return ResponseEntity.ok(updatedTeam);
+    @GetMapping("/{id}")
+    public ResponseEntity<TeamOutDTO> getTeamById(@PathVariable Long id) {
+        return ResponseEntity.status(HttpStatus.FOUND).body(teamService.findById(id));
     }
 
-    @GetMapping("/{id}")
-    public Team getTeamById(@PathVariable Long id) {
-        return teamService.findById(id);
+    @PutMapping("/{id}")
+    public ResponseEntity<TeamOutDTO> updateTeam(@PathVariable Long id,
+                                                 @Valid @RequestBody TeamInDTO dto) {
+        return ResponseEntity.status(HttpStatus.OK).body(teamService.update(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void deleteTeam(@PathVariable Long id) {
         teamService.deleteById(id);
     }
-
 }

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/player/PlayerInDTO.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/player/PlayerInDTO.java
@@ -1,0 +1,32 @@
+package com.tournament_organizer.dto.player;
+
+import com.tournament_organizer.enums.AgeGroup;
+import com.tournament_organizer.enums.Gender;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PlayerInDTO {
+
+    @NotBlank(message = "First name of the player cannot be blank")
+    private String firstName;
+
+    @NotBlank(message = "Second name of player cannot be blank")
+    private String secondName;
+
+    @NotNull(message = "Age is required")
+    @Min(value = 1, message = "Age must be at least 1")
+    private Integer age;
+
+    @NotNull(message = "Gender is required")
+    private Gender gender;
+
+    @NotNull(message = "Level is required")
+    private AgeGroup level;
+
+    private Long teamId;
+}
+

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/player/PlayerOutDTO.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/player/PlayerOutDTO.java
@@ -1,0 +1,31 @@
+package com.tournament_organizer.dto.player;
+
+import com.tournament_organizer.enums.AgeGroup;
+import com.tournament_organizer.enums.Gender;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class PlayerOutDTO {
+    private long id;
+    private String firstName;
+    private String secondName;
+
+    private Integer age;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Enumerated(EnumType.STRING)
+    private AgeGroup level;
+
+    private String associatedTeam;
+
+}

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/team/TeamInDTO.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/team/TeamInDTO.java
@@ -1,0 +1,29 @@
+package com.tournament_organizer.dto.team;
+
+import com.tournament_organizer.enums.AgeGroup;
+import com.tournament_organizer.enums.TeamType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class TeamInDTO {
+
+    @NotBlank
+    private String name;
+
+    @NotNull
+    private AgeGroup ageGroup;
+
+    @NotNull
+    private TeamType teamType;
+
+    // Note: Not mandatory, but we should probably include the option for adding a list of players to the team from the stage of
+    // creation of the team. If we decide to supply a list of Ids for players we can do that as well.
+    private List<Long> playerIds;
+}
+

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/team/TeamOutDTO.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/dto/team/TeamOutDTO.java
@@ -1,0 +1,23 @@
+package com.tournament_organizer.dto.team;
+
+import com.tournament_organizer.dto.player.PlayerOutDTO;
+import com.tournament_organizer.enums.AgeGroup;
+import com.tournament_organizer.enums.TeamType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.List;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class TeamOutDTO {
+    private long id;
+    private String name;
+    private AgeGroup ageGroup;
+    private TeamType type;
+    private List<PlayerOutDTO> players;
+}
+
+

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/mappers/PlayerMapper.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/mappers/PlayerMapper.java
@@ -1,0 +1,72 @@
+package com.tournament_organizer.mappers;
+
+import com.tournament_organizer.dto.player.PlayerInDTO;
+import com.tournament_organizer.dto.player.PlayerOutDTO;
+import com.tournament_organizer.entity.Player;
+import com.tournament_organizer.entity.Team;
+import com.tournament_organizer.exception.ResourceNotFoundException;
+import com.tournament_organizer.repository.PlayerRepository;
+import com.tournament_organizer.repository.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class PlayerMapper {
+    private final TeamRepository teamRepository;
+    private final PlayerRepository playerRepository;
+
+    public Player toEntity(PlayerInDTO playerInDTO) {
+        Player p = new Player();
+        p.setFirstName(playerInDTO.getFirstName());
+        p.setSecondName(playerInDTO.getSecondName());
+        p.setAge(playerInDTO.getAge());
+        p.setLevel(playerInDTO.getLevel());
+
+
+        if (playerInDTO.getTeamId() != null) {
+            Team team = teamRepository.findById(playerInDTO.getTeamId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Team " + playerInDTO.getTeamId() + " not found"));
+            p.setTeam(team);
+        }
+
+        return p;
+    }
+
+    public void updateEntity(Player currentEntity, PlayerInDTO playerInDTO) {
+
+        // Just don't touch the player id.
+        if (playerInDTO.getTeamId() != null) {
+            Team team = teamRepository.findById(playerInDTO.getTeamId())
+                    .orElseThrow(() -> new ResourceNotFoundException("Team " + playerInDTO.getTeamId() + " not found"));
+            currentEntity.setTeam(team);
+        } else {
+            // TODO: Decide what we do if we are passing in a null for the team.
+            //  should we enable the functionality for unassigning a team from a player?
+            currentEntity.setTeam(null);
+        }
+
+        currentEntity.setFirstName(playerInDTO.getFirstName());
+        currentEntity.setFirstName(playerInDTO.getSecondName());
+        currentEntity.setGender(playerInDTO.getGender());
+        currentEntity.setAge(playerInDTO.getAge());
+    }
+
+    public PlayerOutDTO toDto(Player p) {
+        PlayerOutDTO playerOutDTO = new PlayerOutDTO();
+
+        playerOutDTO.setId(p.getId());
+        playerOutDTO.setFirstName(p.getFirstName());
+        playerOutDTO.setSecondName(p.getSecondName());
+        playerOutDTO.setGender(p.getGender());
+        playerOutDTO.setAge(p.getAge());
+        playerOutDTO.setLevel(p.getLevel());
+        if (p.getTeam() != null) {
+            playerOutDTO.setAssociatedTeam(p.getTeam().getName());
+        } else {
+            playerOutDTO.setAssociatedTeam("SINGLE PLAYER");
+        }
+        return playerOutDTO;
+    }
+}

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/mappers/TeamMapper.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/mappers/TeamMapper.java
@@ -1,0 +1,83 @@
+package com.tournament_organizer.mappers;
+
+import com.tournament_organizer.dto.player.PlayerOutDTO;
+import com.tournament_organizer.dto.team.TeamInDTO;
+import com.tournament_organizer.dto.team.TeamOutDTO;
+import com.tournament_organizer.entity.Player;
+import com.tournament_organizer.entity.Team;
+import com.tournament_organizer.exception.ResourceNotFoundException;
+import com.tournament_organizer.repository.PlayerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class TeamMapper {
+
+    private final PlayerRepository playerRepository;
+
+    public Team toEntity(TeamInDTO dto) {
+        Team team = new Team();
+        team.setName(dto.getName());
+        team.setAgeGroup(dto.getAgeGroup());
+        team.setType(dto.getTeamType());
+
+        // Add optional the ability for adding the player ids from the get-go.
+        if (dto.getPlayerIds() != null && !dto.getPlayerIds().isEmpty()) {
+            List<Player> players = dto.getPlayerIds().stream()
+                    .map(id -> playerRepository.findById(id)
+                            .orElseThrow(() -> new ResourceNotFoundException("Player " + id + " not found")))
+                    .collect(Collectors.toList());
+
+            // Set up the bidirectional relationship if needed between the player and the team as necessary.
+            players.forEach(player -> player.setTeam(team));
+            team.setPlayers(players);
+        }
+        return team;
+    }
+
+    public void updateEntity(Team team, TeamInDTO dto) {
+        team.setName(dto.getName());
+        team.setAgeGroup(dto.getAgeGroup());
+        team.setType(dto.getTeamType());
+
+        if (dto.getPlayerIds() != null) {
+            List<Player> players = dto.getPlayerIds().stream()
+                    .map(id -> playerRepository.findById(id)
+                            .orElseThrow(() -> new ResourceNotFoundException("Player " + id + " not found")))
+                    .collect(Collectors.toList());
+
+            players.forEach(player -> player.setTeam(team));
+            team.setPlayers(players);
+        }
+    }
+
+    public TeamOutDTO toDto(Team team) {
+        List<PlayerOutDTO> playerDtos = null;
+        if (team.getPlayers() != null) {
+            playerDtos = team.getPlayers().stream()
+                    .map(player -> new PlayerOutDTO(
+                            player.getId(),
+                            player.getFirstName(),
+                            player.getSecondName(),
+                            player.getAge(),
+                            player.getGender(),
+                            player.getLevel(),
+                            team.getName()
+                )).collect(Collectors.toList());
+        }
+
+        return new TeamOutDTO(
+                team.getId(),
+                team.getName(),
+                team.getAgeGroup(),
+                team.getType(),
+                // TODO: is it okay if this turns out to be null on certain occasions?
+                //  maybe this needs to be checked / tested.
+                playerDtos
+        );
+    }
+}

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/mappers/TournamentMapper.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/mappers/TournamentMapper.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @Component
 @RequiredArgsConstructor
-
 public class TournamentMapper {
     private final VenueRepository venueRepo;
     public Tournament toEntity(TournamentInDTO dto) {

--- a/sports-tournament-organizer/src/main/java/com/tournament_organizer/service/TournamentService.java
+++ b/sports-tournament-organizer/src/main/java/com/tournament_organizer/service/TournamentService.java
@@ -6,12 +6,10 @@ import com.tournament_organizer.entity.Tournament;
 import com.tournament_organizer.exception.ResourceNotFoundException;
 import com.tournament_organizer.mappers.TournamentMapper;
 import com.tournament_organizer.repository.TournamentRepository;
-import org.hibernate.validator.internal.metadata.aggregated.rule.OverridingMethodMustNotAlterParameterConstraints;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
 import java.util.List;
 
 @Service
@@ -23,7 +21,6 @@ public class TournamentService {
         this.tournamentRepository = tournamentRepository;
         this.mapper = mapper;
     }
-
 
     public TournamentOutDTO create(TournamentInDTO dto) {
         Tournament entity = mapper.toEntity(dto);


### PR DESCRIPTION
This pull request contains the changes necessary to improve some of the operations over the Player and Team entities in the application with the help of Input Data Transfer Objects and Output Data Transfer Objects for Player and Team. For this purpose we create mappers, which contain methods for the purpose of enabling easy conversion from an Input DTO to an Entity, from an Entity to DTO, and also for updating a given currently existing entity with the help of a PatchDTO. In this way we can more easily manage the bidirectional relationship between Players and Teams and we can ensure that if a change happens within one of these entities it is correctly reflected in the other entity as well. This enables us to easily change the Teams of the Players and properly display that back to user when necessary. 
